### PR TITLE
Hide the non used extra apps

### DIFF
--- a/dask-sql/files/hue.ini
+++ b/dask-sql/files/hue.ini
@@ -1,4 +1,6 @@
 [desktop]
+    app_blacklist=zookeeper,hbase,security,search,sqoop,oozie,filebrowser,jobbrowser,spark,pig,jobsub
+    
     [[database]]
     engine=mysql
     host=hue-mysql


### PR DESCRIPTION
To only show the SQL Editor and Table Browser, not everything https://miro.medium.com/max/2400/1*lFKvpYch-T8u3q14vEjuvQ.png

Note: I did not test it in your repo